### PR TITLE
create test-jar, which is used by the log4j-core-its module

### DIFF
--- a/log4j-server/pom.xml
+++ b/log4j-server/pom.xml
@@ -125,6 +125,17 @@
           </instructions>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <reporting>


### PR DESCRIPTION
required to fix log4j2 build on travis (see https://github.com/apache/logging-log4j2/pull/102)