### PR TITLE
Normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+# All text files should use LF for reproducibility of builds
+* text=auto eol=lf
 # Maven Wrapper need LF line endings
 /.mvn/wrapper/maven-wrapper.properties eol=lf
 /mvnw                                  eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ target/
 .project
 .classpath
 .settings/
+# Maven Wrapper
+/.mvn/wrapper/maven-wrapper.jar

--- a/mvnw
+++ b/mvnw
@@ -298,11 +298,14 @@ MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $*"
 export MAVEN_CMD_LINE_ARGS
 
 WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+LINE_SEPARATOR="
+"
 
 # shellcheck disable=SC2086 # safe args
 exec "$JAVACMD" \
   $MAVEN_OPTS \
   $MAVEN_DEBUG_OPTS \
+  "-Dline.separator=$LINE_SEPARATOR" \
   -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
   "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
   ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -174,11 +174,18 @@ IF NOT %WRAPPER_SHA_256_SUM%=="" (
 @REM Provide a "standardized" way to retrieve the CLI args that will
 @REM work with both Windows and non-Windows executions.
 set MAVEN_CMD_LINE_ARGS=%*
+@REM Do not remove the blank lines
+(set \n=^^^
+
+^
+
+)
 
 %MAVEN_JAVA_EXE% ^
   %JVM_CONFIG_MAVEN_PROPS% ^
   %MAVEN_OPTS% ^
   %MAVEN_DEBUG_OPTS% ^
+  -Dline.separator=%\n% ^
   -classpath %WRAPPER_JAR% ^
   "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
   %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*


### PR DESCRIPTION
We want to achieve a higher reproducibility standard on Windows: if a Windows user checks out this repository and compiles a `rel/x.x.x` tag, he should obtain exactly the same JAR files as those published.

Therefore we need to normalize the line endings of all text resources to LF. This closes #29.
