### PR TITLE
Downgrade Maven API version to 3.6.0

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,8 +20,11 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-      time: "04:00"
     open-pull-requests-limit: 10
+    ignore:
+      # Keep at version 3.6.x
+      - dependency-name: "org.apache.maven:maven-plugin-api"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/log4j-tools-parent/pom.xml
+++ b/log4j-tools-parent/pom.xml
@@ -57,7 +57,7 @@
     <freemarker.version>2.3.32</freemarker.version>
     <junit.version>5.9.2</junit.version>
     <maven-plugin.version>3.7.1</maven-plugin.version>
-    <maven-plugin-api.version>3.9.0</maven-plugin-api.version>
+    <maven-plugin-api.version>3.6.0</maven-plugin-api.version>
     <spotbugs.version>4.7.3</spotbugs.version>
 
     <!-- plugin versions -->


### PR DESCRIPTION
This fixes #28: the version of the Maven Plugin API will not be upgraded.
