### PR TITLE
Fix plugin subclassing in Log4j Docgen

### DIFF
--- a/log4j-docgen/src/main/java/org/apache/logging/log4j/docgen/generator/internal/TypeLookup.java
+++ b/log4j-docgen/src/main/java/org/apache/logging/log4j/docgen/generator/internal/TypeLookup.java
@@ -16,17 +16,16 @@
  */
 package org.apache.logging.log4j.docgen.generator.internal;
 
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Predicate;
 import org.apache.logging.log4j.docgen.AbstractType;
 import org.apache.logging.log4j.docgen.PluginSet;
 import org.apache.logging.log4j.docgen.PluginType;
 import org.apache.logging.log4j.docgen.ScalarType;
 import org.apache.logging.log4j.docgen.Type;
 import org.jspecify.annotations.Nullable;
-
-import java.util.Iterator;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.function.Predicate;
 
 public final class TypeLookup extends TreeMap<String, ArtifactSourcedType> {
 
@@ -54,7 +53,6 @@ public final class TypeLookup extends TreeMap<String, ArtifactSourcedType> {
     @SuppressWarnings("StatementWithEmptyBody")
     private void mergeScalarTypes(PluginSet pluginSet) {
         pluginSet.getScalars().forEach(newType -> {
-
             final String className = newType.getClassName();
             @Nullable final ArtifactSourcedType oldSourcedType = get(className);
 
@@ -67,7 +65,8 @@ public final class TypeLookup extends TreeMap<String, ArtifactSourcedType> {
             // If the entry already exists and is of expected type, we should ideally extend it.
             // Since Modello doesn't generate `hashCode()`, `equals()`, etc. it is difficult to compare instances.
             // Hence, we will be lazy, and just assume they are the same.
-            else if (oldSourcedType.type instanceof ScalarType) {}
+            else if (oldSourcedType.type instanceof ScalarType) {
+            }
 
             // If the entry already exists, but with an unexpected type, fail
             else {
@@ -87,7 +86,6 @@ public final class TypeLookup extends TreeMap<String, ArtifactSourcedType> {
 
     private void mergeAbstractTypes(PluginSet pluginSet) {
         pluginSet.getAbstractTypes().forEach(newType -> {
-
             final String className = newType.getClassName();
             @Nullable final ArtifactSourcedType oldSourcedType = get(className);
 
@@ -112,7 +110,6 @@ public final class TypeLookup extends TreeMap<String, ArtifactSourcedType> {
 
     private void mergePluginTypes(PluginSet pluginSet) {
         pluginSet.getPlugins().forEach(newType -> {
-
             final String className = newType.getClassName();
             @Nullable final ArtifactSourcedType oldSourcedType = get(className);
 

--- a/src/changelog/.0.x.x/fix-docgen-duplicate-type.xml
+++ b/src/changelog/.0.x.x/fix-docgen-duplicate-type.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="117" link="https://github.com/apache/logging-log4j-tools/issues/117"/>
+  <description format="asciidoc">Fix handling of subclassed plugins in Log4j Docgen</description>
+</entry>


### PR DESCRIPTION
This change fixes #117, which misses `loggers > logger` entry.

### Why is the entry missing?

`log4j-core-plugins.xml` contains two entries for `LoggerConfig`:

1. `<abstractType className="org.apache.logging.log4j.core.config.LoggerConfig">`
2. `<plugin name="logger" className="org.apache.logging.log4j.core.config.LoggerConfig">`

`TypeLookup` encounters the `<abstractType` first and consequently discards the `<plugin`, hence `logger` doesn't show up in the `LoggerConfig` XSD `group`.

### How shall we solve the problem?

If an FQCN is a plugin and is also subclassed by other plugins:

1. `DescriptorGenerator` should not generate an `AbstractType`, but only a `PluginType`.
2. `TypeLookup` should promote an `AbstractType` to a `PluginType` if the associated FQCN is later on found to be a plugin. (This can still be the case even after the `DescriptorGenerator` fix mentioned above. That is, the plugin and the subclassed plugin can be provided in different descriptor files.)