### PR TITLE
Add support for `@PluginValue` annotation

### DIFF
--- a/log4j-docgen/src/main/java/org/apache/logging/log4j/docgen/processor/Annotations.java
+++ b/log4j-docgen/src/main/java/org/apache/logging/log4j/docgen/processor/Annotations.java
@@ -53,8 +53,10 @@ final class Annotations {
     private static final Collection<String> PLUGIN_ATTRIBUTE_ANNOTATION_NAMES = Arrays.asList(
             "org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute",
             "org.apache.logging.log4j.core.config.plugins.PluginAttribute",
+            "org.apache.logging.log4j.core.config.plugins.PluginValue",
             "org.apache.logging.log4j.plugins.PluginAttribute",
-            "org.apache.logging.log4j.plugins.PluginBuilderAttribute");
+            "org.apache.logging.log4j.plugins.PluginBuilderAttribute",
+            "org.apache.logging.log4j.plugins.PluginValue");
     private static final Collection<String> PLUGIN_ELEMENT_ANNOTATION_NAMES = Arrays.asList(
             "org.apache.logging.log4j.core.config.plugins.PluginElement",
             "org.apache.logging.log4j.plugins.PluginElement");

--- a/log4j-docgen/src/test/resources/DescriptorGeneratorTest/expected-plugins.xml
+++ b/log4j-docgen/src/test/resources/DescriptorGeneratorTest/expected-plugins.xml
@@ -86,6 +86,9 @@
                     <description>A `String` attribute.</description>
                 </attribute>
                 <attribute name="undocumentedAttribute" type="double"/>
+                <attribute name="valueAttribute" type="int">
+                    <description>An attribute that can be also be inserted as content of the XML element.</description>
+                </attribute>
             </attributes>
             <elements>
                 <element type="example.AbstractAppender">
@@ -153,6 +156,9 @@ It also implements:
                 </attribute>
                 <attribute name="doubleAttr" type="double">
                     <description>A `double` attribute.</description>
+                </attribute>
+                <attribute name="elementValue" type="int">
+                    <description>An attribute that can be also be inserted as content of the XML element.</description>
                 </attribute>
                 <attribute name="enumAttr" type="example.MyEnum">
                     <description>An `enum` attribute.</description>

--- a/log4j-docgen/src/test/resources/DescriptorGeneratorTest/java-of-log4j2/MyAppender.java
+++ b/log4j-docgen/src/test/resources/DescriptorGeneratorTest/java-of-log4j2/MyAppender.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.plugins.PluginValue;
 
 /**
  * Example plugin
@@ -114,6 +115,11 @@ public class MyAppender extends AbstractAppender implements Appender {
         private @PluginBuilderAttribute double aDouble;
 
         private @PluginBuilderAttribute double undocumentedAttribute;
+
+        /**
+         * An attribute that can be also be inserted as content of the XML element.
+         */
+        private @PluginValue int valueAttribute;
 
         private Object notAnAttribute;
 

--- a/log4j-docgen/src/test/resources/DescriptorGeneratorTest/java-of-log4j2/MyOldLayout.java
+++ b/log4j-docgen/src/test/resources/DescriptorGeneratorTest/java-of-log4j2/MyOldLayout.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.plugins.PluginValue;
 
 /**
  * Example plugin without a builder.
@@ -42,6 +43,7 @@ public final class MyOldLayout implements Layout {
      * @param enumAttr An {@code enum} attribute.
      * @param nestedLayout An element with multiplicity {@code 1}.
      * @param filters An element with multiplicity {@code n}.
+     * @param valueAttribute An attribute that can be also be inserted as content of the XML element.
      */
     @PluginFactory
     public static MyOldLayout newLayout(
@@ -57,7 +59,8 @@ public final class MyOldLayout implements Layout {
             final @PluginAttribute("otherName") String origName,
             final @PluginAttribute("enumAttr") MyEnum enumAttr,
             final @PluginElement("nestedLayout") Layout nestedLayout,
-            final @PluginElement("filters") Filter[] filters) {
+            final @PluginElement("filters") Filter[] filters,
+            final @PluginValue("elementValue") int valueAttribute) {
         return null;
     }
 }

--- a/log4j-docgen/src/test/resources/DescriptorGeneratorTest/java-of-log4j3/MyAppender.java
+++ b/log4j-docgen/src/test/resources/DescriptorGeneratorTest/java-of-log4j3/MyAppender.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.plugins.PluginAttribute;
 import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
+import org.apache.logging.log4j.plugins.PluginValue;
 import org.apache.logging.log4j.plugins.validation.constraints.Required;
 
 /**
@@ -117,6 +118,11 @@ public class MyAppender extends AbstractAppender implements Appender {
         private @PluginBuilderAttribute double aDouble;
 
         private @PluginBuilderAttribute double undocumentedAttribute;
+
+        /**
+         * An attribute that can be also be inserted as content of the XML element.
+         */
+        private @PluginValue int valueAttribute;
 
         private Object notAnAttribute;
 

--- a/log4j-docgen/src/test/resources/DescriptorGeneratorTest/java-of-log4j3/MyOldLayout.java
+++ b/log4j-docgen/src/test/resources/DescriptorGeneratorTest/java-of-log4j3/MyOldLayout.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.plugins.Factory;
 import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginAttribute;
 import org.apache.logging.log4j.plugins.PluginElement;
+import org.apache.logging.log4j.plugins.PluginValue;
 import org.apache.logging.log4j.plugins.validation.constraints.Required;
 
 /**
@@ -42,6 +43,7 @@ public final class MyOldLayout implements Layout {
      * @param enumAttr An {@code enum} attribute.
      * @param nestedLayout An element with multiplicity {@code 1}.
      * @param filters An element with multiplicity {@code n}.
+     * @param valueAttribute An attribute that can be also be inserted as content of the XML element.
      */
     @Factory
     public static MyOldLayout newLayout(
@@ -57,7 +59,8 @@ public final class MyOldLayout implements Layout {
             final @PluginAttribute("otherName") String origName,
             final @PluginAttribute MyEnum enumAttr,
             final @PluginElement Layout nestedLayout,
-            final @PluginElement Filter[] filters) {
+            final @PluginElement Filter[] filters,
+            final @PluginValue("elementValue") int valueAttribute) {
         return null;
     }
 }

--- a/src/changelog/0.9.0/add-plugin-value-annotation.xml
+++ b/src/changelog/0.9.0/add-plugin-value-annotation.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <issue id="123" link="https://github.com/apache/logging-log4j-tools/pull/123"/>
+  <description format="asciidoc">Add support for the `@PluginValue` annotation.</description>
+</entry>


### PR DESCRIPTION
We add support for the
[@PluginValue](https://logging.apache.org/log4j/2.x/javadoc/log4j-core/org/apache/logging/log4j/core/config/plugins/PluginValue.html) annotation.

