### PR TITLE
log4j-docgen: Support boxed and native Java types in XSD generation

### DIFF
--- a/log4j-docgen/src/test/resources/SchemaGeneratorTest/expected-plugins.xsd
+++ b/log4j-docgen/src/test/resources/SchemaGeneratorTest/expected-plugins.xsd
@@ -19,7 +19,8 @@
   ~ This is a test schema used in `SchemaGeneratorTest`.
   ~ Unlike this file the `SchemaGenerator` strips whitespace.
   -->
-<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:log4j="https://logging.apache.org/xml/ns" elementFormDefault="qualified" targetNamespace="https://logging.apache.org/xml/ns" version="1.2.3">
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:log4j="https://logging.apache.org/xml/ns"
+        elementFormDefault="qualified" targetNamespace="https://logging.apache.org/xml/ns" version="1.2.3">
   <element type="log4j:org.apache.logging.log4j.core.config.Configuration" name="Configuration"/>
   <simpleType name="org.apache.logging.log4j.Level">
     <annotation>
@@ -499,5 +500,29 @@ A conversion pattern is composed of literal text and format control expressions 
         <documentation>The pattern to use to format log events.</documentation>
       </annotation>
     </attribute>
+  </complexType>
+  <complexType name="org.apache.logging.log4j.dummy.AllTypesPlugin">
+    <annotation>
+      <documentation>Dummy plugin to test all types of builtin XML attributes.</documentation>
+    </annotation>
+    <attribute name="BigInteger" type="integer"/>
+    <attribute name="BigDecimal" type="decimal"/>
+    <attribute name="boolean" type="boolean"/>
+    <attribute name="Boolean" type="boolean"/>
+    <attribute name="byte" type="byte"/>
+    <attribute name="Byte" type="byte"/>
+    <attribute name="double" type="double"/>
+    <attribute name="Double" type="double"/>
+    <attribute name="float" type="float"/>
+    <attribute name="Float" type="float"/>
+    <attribute name="int" type="int"/>
+    <attribute name="Integer" type="int"/>
+    <attribute name="long" type="long"/>
+    <attribute name="Long" type="long"/>
+    <attribute name="short" type="short"/>
+    <attribute name="Short" type="short"/>
+    <attribute name="String" type="string"/>
+    <attribute name="URI" type="anyURI"/>
+    <attribute name="URL" type="anyURI"/>
   </complexType>
 </schema>

--- a/log4j-docgen/src/test/resources/SchemaGeneratorTest/plugins.xml
+++ b/log4j-docgen/src/test/resources/SchemaGeneratorTest/plugins.xml
@@ -267,6 +267,31 @@ A conversion pattern is composed of literal text and format control expressions 
                 </attribute>
             </attributes>
         </plugin>
+
+        <plugin name="AllTypes" className="org.apache.logging.log4j.dummy.AllTypesPlugin">
+            <description>Dummy plugin to test all types of builtin XML attributes.</description>
+            <attributes>
+                <attribute name="BigInteger" type="java.math.BigInteger"/>
+                <attribute name="BigDecimal" type="java.math.BigDecimal"/>
+                <attribute name="boolean" type="boolean"/>
+                <attribute name="Boolean" type="java.lang.Boolean"/>
+                <attribute name="byte" type="byte"/>
+                <attribute name="Byte" type="java.lang.Byte"/>
+                <attribute name="double" type="double"/>
+                <attribute name="Double" type="java.lang.Double"/>
+                <attribute name="float" type="float"/>
+                <attribute name="Float" type="java.lang.Float"/>
+                <attribute name="int" type="int"/>
+                <attribute name="Integer" type="java.lang.Integer"/>
+                <attribute name="long" type="long"/>
+                <attribute name="Long" type="java.lang.Long"/>
+                <attribute name="short" type="short"/>
+                <attribute name="Short" type="java.lang.Short"/>
+                <attribute name="String" type="java.lang.String"/>
+                <attribute name="URI" type="java.net.URI"/>
+                <attribute name="URL" type="java.net.URL"/>
+            </attributes>
+        </plugin>
     </plugins>
 
     <abstractTypes>

--- a/src/changelog/.0.x.x/135_native-types.xml
+++ b/src/changelog/.0.x.x/135_native-types.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="135" link="https://github.com/apache/logging-log4j-tools/issues/135"/>
+  <description format="asciidoc">Fix support of boxed and native Java types in XSD generation.</description>
+</entry>


### PR DESCRIPTION
Previously, `SchemaGenerator` did not handle configuration attributes with boxed types (e.g., `Integer`, `Boolean`), leading to their omission from the generated XSD schema.

This update introduces:

* Support for boxed Java types as configuration attributes.
* Improved handling of other native Java types that map to XML built-in data types (e.g., `BigDecimal`, `URL`).

These enhancements ensure that all relevant configuration attributes are accurately represented in the schema.

Fixes #135

